### PR TITLE
Print "hello world" before each task run

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -76,6 +76,7 @@ class DefaultAgent:
 
     def run(self, task: str = "", **kwargs) -> dict:
         """Run step() until agent is finished. Returns dictionary with exit_status, submission keys."""
+        print("hello world")
         self.extra_template_vars |= {"task": task, **kwargs}
         self.messages = []
         self.add_messages(

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -423,3 +423,13 @@ def test_empty_actions_handling(model_factory):
     assert info["exit_status"] == "Submitted"
     assert info["submission"] == "done\n"
     assert agent.n_calls == 2
+
+
+def test_hello_world_printed_before_task(model_factory, capsys):
+    """Test that 'hello world' is printed before each task starts."""
+    factory, config = model_factory
+    outputs = [("Done", [{"command": "echo 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'\necho 'ok'"}])]
+    for _ in range(2):
+        DefaultAgent(model=factory(outputs), env=LocalEnvironment(), **config).run("task")
+    captured = capsys.readouterr()
+    assert captured.out.count("hello world\n") == 2


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#769](https://github.com/SWE-agent/mini-swe-agent/pull/769)
> **Original author:** @app/copilot-swe-agent
> **Originally opened:** 2026-03-05

---

Prints `hello world` to stdout at the start of every task execution.

## Changes

- **`agents/default.py`**: Added `print("hello world")` as the first statement in `DefaultAgent.run()`.
- **`tests/agents/test_default.py`**: Added `test_hello_world_printed_before_task` to assert the message is printed once per task invocation across all model format variants.

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)
