### PR TITLE
fix(modal): Add missing exception_info to SwerexModalEnvironment output

### DIFF
--- a/src/minisweagent/environments/extra/swerex_modal.py
+++ b/src/minisweagent/environments/extra/swerex_modal.py
@@ -63,23 +63,28 @@ class SwerexModalEnvironment:
     def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in the environment and return the raw output."""
         command = action.get("command", "") if isinstance(action, dict) else action
-        output = asyncio.run(
-            self.deployment.runtime.execute(
-                RexCommand(
-                    command=command,
-                    shell=True,
-                    check=False,
-                    cwd=cwd or self.config.cwd,
-                    timeout=timeout or self.config.timeout,
-                    merge_output_streams=True,
-                    env=self.config.env if self.config.env else None,
+        try:
+            result = asyncio.run(
+                self.deployment.runtime.execute(
+                    RexCommand(
+                        command=command,
+                        shell=True,
+                        check=False,
+                        cwd=cwd or self.config.cwd,
+                        timeout=timeout or self.config.timeout,
+                        merge_output_streams=True,
+                        env=self.config.env if self.config.env else None,
+                    )
                 )
             )
-        )
-        output = {
-            "output": output.stdout,
-            "returncode": output.exit_code,
-        }
+            output = {"output": result.stdout, "returncode": result.exit_code, "exception_info": ""}
+        except Exception as e:
+            output = {
+                "output": str(e) if str(e) else "",
+                "returncode": -1,
+                "exception_info": f"An error occurred while executing the command: {e}",
+                "extra": {"exception_type": type(e).__name__, "exception": str(e)},
+            }
         self._check_finished(output)
         return output
 


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#764](https://github.com/SWE-agent/mini-swe-agent/pull/764)
> **Original author:** @AlienKevin
> **Originally opened:** 2026-03-01

---

## Summary
- After recent v2 changes, the `execute()` method in `SwerexModalEnvironment` was missing the `exception_info` key in its return dict, unlike all other environment implementations (docker, local, singularity, swerex_docker). This caused a Jinja2 `UndefinedError` when the observation template accessed `output.exception_info` with `StrictUndefined`, crashing the agent on every step.
- Also adds `try/except` around the execute call to match `swerex_docker`, so execution errors are returned as structured output instead of propagating as unhandled exceptions.

## Test plan
- [x] Verified fix by running `mini-extra swebench` with Modal environment on SWE-smith-rs tasks — all instances now complete successfully instead of failing with `UndefinedError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
