### PR TITLE
fix(inspector): Handle ANSI escape sequences and null bytes in content

### DIFF
--- a/src/minisweagent/run/utilities/inspector.py
+++ b/src/minisweagent/run/utilities/inspector.py
@@ -203,7 +203,8 @@ class TrajectoryInspector(App):
             container.mount(message_container)
             role = message.get("role") or message.get("type") or "unknown"
             message_container.mount(Static(role.upper(), classes="message-header"))
-            message_container.mount(Static(Text(content_str, no_wrap=False), classes="message-content"))
+            clean_str = content_str.replace("\x00", "")
+            message_container.mount(Static(Text.from_ansi(clean_str, no_wrap=False), classes="message-content"))
 
         self.title = (
             f"Trajectory {self.i_trajectory + 1}/{self.n_trajectories} - "


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#761](https://github.com/SWE-agent/mini-swe-agent/pull/761)
> **Original author:** @klieret
> **Originally opened:** 2026-02-27

---

Use Text.from_ansi() instead of Text() to prevent raw terminal control
sequences (e.g. from TUI program output) from leaking to the host
terminal and freezing the inspector.
