### PR TITLE
Remove whitespace and check if args is a dict to avoid exceptions fro…

### DIFF
--- a/src/minisweagent/models/utils/actions_toolcall.py
+++ b/src/minisweagent/models/utils/actions_toolcall.py
@@ -47,10 +47,10 @@ def parse_toolcall_actions(tool_calls: list, *, format_error_template: str) -> l
         try:
             args = json.loads(tool_call.function.arguments)
         except Exception as e:
-            error_msg = f"Error parsing tool call arguments: {e}. "
+            error_msg = f"Error parsing tool call arguments: {e}."
         if tool_call.function.name != "bash":
             error_msg += f"Unknown tool '{tool_call.function.name}'."
-        if "command" not in args:
+        if not isinstance(args, dict) or "command" not in args:
             error_msg += "Missing 'command' argument in bash tool call."
         if error_msg:
             raise FormatError(

--- a/src/minisweagent/models/utils/actions_toolcall_response.py
+++ b/src/minisweagent/models/utils/actions_toolcall_response.py
@@ -62,10 +62,10 @@ def parse_toolcall_actions_response(output: list, *, format_error_template: str)
         try:
             args = json.loads(tool_call.get("arguments", "{}"))
         except Exception as e:
-            error_msg = f"Error parsing tool call arguments: {e}. "
+            error_msg = f"Error parsing tool call arguments: {e}."
         if tool_call.get("name") != "bash":
             error_msg += f"Unknown tool '{tool_call.get('name')}'."
-        if "command" not in args:
+        if not isinstance(args, dict) or "command" not in args:
             error_msg += "Missing 'command' argument in bash tool call."
         if error_msg:
             error_text = Template(format_error_template, undefined=StrictUndefined).render(


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#760](https://github.com/SWE-agent/mini-swe-agent/pull/760)
> **Original author:** @RobinChiu
> **Originally opened:** 2026-02-25

---

1. Remove the extra whitespace.
2. When arguments= '["command", "sed -n \'1320,1350p\' astropy/io/fits/card.py"]' it will parse to list and pass the 
if "command" not in args check. 
