### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         exclude: pyproject.toml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#757](https://github.com/SWE-agent/mini-swe-agent/pull/757)
> **Original author:** @app/pre-commit-ci
> **Originally opened:** 2026-02-23

---

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.15.1 → v0.15.2](https://github.com/astral-sh/ruff-pre-commit/compare/v0.15.1...v0.15.2)
<!--pre-commit.ci end-->
