### PR TITLE
Fix: Update SwerexModalEnvironment for v2 Environment protocol

### DIFF
--- a/tests/environments/extra/test_swerex_modal.py
+++ b/tests/environments/extra/test_swerex_modal.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from minisweagent.environments.extra.swerex_modal import (
+    SwerexModalEnvironment,
+    SwerexModalEnvironmentConfig,
+)
+from minisweagent.exceptions import Submitted
+
+
+def _make_env(**kwargs):
+    """Create a SwerexModalEnvironment with mocked __init__ (no Modal infra)."""
+    with patch.object(SwerexModalEnvironment, "__init__", lambda self, **kw: None):
+        env = SwerexModalEnvironment()
+        env.config = SwerexModalEnvironmentConfig(image="python:3.11", **kwargs)
+        return env
+
+
+def test_swerex_modal_serialize():
+    """Test that SwerexModalEnvironment.serialize() returns the expected structure."""
+    env = _make_env()
+    result = env.serialize()
+
+    assert "info" in result
+    assert "config" in result["info"]
+    assert "environment" in result["info"]["config"]
+    assert "environment_type" in result["info"]["config"]
+    assert result["info"]["config"]["environment"]["image"] == "python:3.11"
+    assert "SwerexModalEnvironment" in result["info"]["config"]["environment_type"]
+
+
+def test_swerex_modal_execute_accepts_dict_action():
+    """Test that execute() accepts v2 dict action format."""
+    env = _make_env()
+
+    mock_output = MagicMock()
+    mock_output.stdout = "hello world\n"
+    mock_output.exit_code = 0
+
+    mock_runtime = MagicMock()
+    mock_runtime.execute = AsyncMock(return_value=mock_output)
+
+    mock_deployment = MagicMock()
+    mock_deployment.runtime = mock_runtime
+    env.deployment = mock_deployment
+
+    result = env.execute({"command": "echo hello world"})
+
+    assert result["output"] == "hello world\n"
+    assert result["returncode"] == 0
+
+
+def test_swerex_modal_execute_raises_submitted():
+    """Test that execute() raises Submitted when output contains the submission marker."""
+    env = _make_env()
+
+    mock_output = MagicMock()
+    mock_output.stdout = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\ndiff --git a/file.py b/file.py\n"
+    mock_output.exit_code = 0
+
+    mock_runtime = MagicMock()
+    mock_runtime.execute = AsyncMock(return_value=mock_output)
+
+    mock_deployment = MagicMock()
+    mock_deployment.runtime = mock_runtime
+    env.deployment = mock_deployment
+
+    with pytest.raises(Submitted) as exc_info:
+        env.execute({"command": "echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT && git diff"})
+
+    msg = exc_info.value.messages[0]
+    assert msg["extra"]["exit_status"] == "Submitted"
+    assert "diff --git" in msg["extra"]["submission"]


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#747](https://github.com/SWE-agent/mini-swe-agent/pull/747)
> **Original author:** @arbipher
> **Originally opened:** 2026-02-18

---

The code change and PR were initialized by Claude, but I tested it and checked it on my previous workload.
I have also read the Contributing, including `pre-commit` and `pytest`. Some code is learnby from `swerex_docker.py`.

---

Add missing `serialize()` method, matching the pattern used by `DockerEnvironment` and `LocalEnvironment`
Update `execute()` to accept `action: dict` instead of `command: str`, aligning with the v2 Environment protocol where actions are passed as dicts with a "command" key
Add missing `_check_finished()` method to detect `COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT` and raise `Submitted`, matching all other environment implementations
Add tests for all three fixes
