### PR TITLE
litellm default timeout is 600s. Change it to 60s for swebench.

### DIFF
--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -175,3 +175,4 @@ model:
     drop_params: true
     temperature: 0.0
     parallel_tool_calls: true
+    timeout: 60


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#740](https://github.com/SWE-agent/mini-swe-agent/pull/740)
> **Original author:** @RobinChiu
> **Originally opened:** 2026-02-11

---

Set the litellm timeout to 60s when run the swebench. 
