### PR TITLE
Fixes #710: Apptainer fakeroot fix

### DIFF
--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -28,6 +28,10 @@ class SingularityEnvironmentConfig(BaseModel):
     """Path to the singularity executable."""
     sandbox_build_retries: int = 3
     """Number of retries for building the sandbox if an error occurs."""
+    global_args: list[str] = ["--quiet"]
+    """Global arguments passed before the subcommand (e.g., --quiet, --debug)."""
+    exec_args: list[str] = ["--contain", "--cleanenv", "--fakeroot"]
+    """Arguments passed to `singularity exec`."""
 
 
 class SingularityEnvironment:
@@ -76,10 +80,7 @@ class SingularityEnvironment:
     def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in a Singularity container and return the result as a dict."""
         command = action.get("command", "")
-        cmd = [self.config.executable, "exec"]
-
-        # Do not inherit directories and env vars from host
-        cmd.extend(["--contain", "--cleanenv"])
+        cmd = [self.config.executable, *self.config.global_args, "exec", *self.config.exec_args]
 
         work_dir = cwd or self.config.cwd
         if work_dir and work_dir != "/":

--- a/tests/environments/test_singularity.py
+++ b/tests/environments/test_singularity.py
@@ -27,6 +27,8 @@ def test_singularity_environment_config_defaults():
     assert config.forward_env == []
     assert config.timeout == 30
     assert config.executable == "singularity"
+    assert config.global_args == ["--quiet"]
+    assert config.exec_args == ["--contain", "--cleanenv", "--fakeroot"]
 
 
 @pytest.mark.slow
@@ -160,3 +162,17 @@ def test_singularity_environment_timeout():
     assert result["returncode"] == -1
     assert "timed out" in result["exception_info"]
     assert result["extra"]["exception_type"] == "TimeoutExpired"
+
+@pytest.mark.slow
+@pytest.mark.skipif(not is_singularity_available(), reason="Singularity not available")
+def test_singularity_environment_writable_sandbox():
+    """Test that the sandbox is writable"""
+    env = SingularityEnvironment(image="docker://python:3.11-slim")
+
+    result = env.execute({"command": "echo 'test content' > /tmp/test_file.txt && cat /tmp/test_file.txt"})
+    assert result["returncode"] == 0
+    assert "test content" in result["output"]
+
+    result = env.execute({"command": "touch /usr/testfile && ls /usr/testfile"})
+    assert result["returncode"] == 0
+    assert "/usr/testfile" in result["output"]

--- a/tests/environments/test_singularity.py
+++ b/tests/environments/test_singularity.py
@@ -163,6 +163,7 @@ def test_singularity_environment_timeout():
     assert "timed out" in result["exception_info"]
     assert result["extra"]["exception_type"] == "TimeoutExpired"
 
+
 @pytest.mark.slow
 @pytest.mark.skipif(not is_singularity_available(), reason="Singularity not available")
 def test_singularity_environment_writable_sandbox():


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#729](https://github.com/SWE-agent/mini-swe-agent/pull/729)
> **Original author:** @hubstrauss
> **Originally opened:** 2026-02-06

---

Adding `--fakeroot` (and `--quiet`) as default flags for singularity execs to solve the no root access issue on HPCs that use apptainer

Fixes https://github.com/SWE-agent/mini-swe-agent/issues/710
