### PR TITLE
Fix swebench-single output path

### DIFF
--- a/src/minisweagent/run/benchmarks/swebench_single.py
+++ b/src/minisweagent/run/benchmarks/swebench_single.py
@@ -74,6 +74,7 @@ def main(
         configs.append({"model": {"model_name": model_name}})
     if exit_immediately:
         configs.append({"agent": {"confirm_exit": False}})
+    configs.append({"agent": {"output_path": output}})
     config = recursive_merge(*configs)
 
     env = get_sb_environment(config, instance)

--- a/tests/run/test_swebench_single.py
+++ b/tests/run/test_swebench_single.py
@@ -39,6 +39,7 @@ def test_swebench_single_end_to_end(github_test_data, tmp_path):
         mock_get_model.return_value = _make_model_from_fixture(model_responses, cost_per_call=0.1)
 
         # Test with explicit instance ID
+        output_path = tmp_path / "test_output.json"
         main(
             subset="_test",
             split="test",
@@ -47,11 +48,12 @@ def test_swebench_single_end_to_end(github_test_data, tmp_path):
             config_spec=[str(package_dir / "config" / "benchmarks" / "swebench.yaml")],
             environment_class="docker",
             exit_immediately=False,
-            output=tmp_path / "test_output.json",
+            output=output_path,
         )
 
         # Verify model was called with correct parameters
         mock_get_model.assert_called_once()
+        assert output_path.exists()
 
 
 @pytest.mark.slow
@@ -72,6 +74,7 @@ def test_swebench_single_end_to_end_exit_immediately(github_test_data, tmp_path)
         mock_get_model.return_value = _make_model_from_fixture(model_responses, cost_per_call=0.1)
 
         # Test with explicit instance ID
+        output_path = tmp_path / "test_output.json"
         main(
             subset="_test",
             split="test",
@@ -80,8 +83,9 @@ def test_swebench_single_end_to_end_exit_immediately(github_test_data, tmp_path)
             config_spec=[str(package_dir / "config" / "benchmarks" / "swebench.yaml")],
             environment_class="docker",
             exit_immediately=True,
-            output=tmp_path / "test_output.json",
+            output=output_path,
         )
 
         # Verify model was called with correct parameters
         mock_get_model.assert_called_once()
+        assert output_path.exists()


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#726](https://github.com/SWE-agent/mini-swe-agent/pull/726)
> **Original author:** @SailorJoe6
> **Originally opened:** 2026-02-04

---

Fixes #725 

  # Summary
  swebench-single currently ignores the -o/--output flag and does not write the
  trajectory to the requested path. This PR sets agent.output_path from the CLI --output
  option so the final trajectory is saved where the user specifies.

  # Changes

  - Set agent.output_path from --output in swebench_single.py.
  - Tests: verify the output file is created when --output is passed.

  # Why
  The CLI advertises -o/--output as the destination for the trajectory, but the file is
  not written there. This is confusing for users and breaks scripting workflows.

  # Testing
  python -m pytest -q tests/run/test_swebench_single.py
