### PR TITLE
Enable parallel tool calls and use plain text observation template

### DIFF
--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -20,7 +20,7 @@ agent:
     For each response:
 
     1. Include a THOUGHT section explaining your reasoning and what you're trying to accomplish
-    2. Provide exactly ONE bash command to execute
+    2. Provide one or more bash tool calls to execute
 
     ## Important Boundaries
 
@@ -52,15 +52,15 @@ agent:
     **CRITICAL REQUIREMENTS:**
 
     - Your response SHOULD include reasoning text explaining what you're doing
-    - Your response MUST include AT LEAST ONE bash tool call
+    - Your response MUST include AT LEAST ONE bash tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase). This saves rounds and is strongly encouraged during exploration.
     - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
     - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
 
     Example of a CORRECT response:
     <example_response>
-    I need to understand the structure of the repository first. Let me check what files are in the current directory to get a better understanding of the codebase.
+    I need to understand the Builder-related code. Let me find relevant files and check the project structure.
 
-    [Makes bash tool call with {"command": "ls -la"} as arguments]
+    [Makes multiple bash tool calls: {"command": "ls -la"}, {"command": "find src -name '*.java' | grep -i builder"}, {"command": "cat README.md | head -50"}]
     </example_response>
 
     ## Environment Details
@@ -125,22 +125,16 @@ environment:
 
 model:
   observation_template: |
+    {%- if output.exception_info %}Exception: {{ output.exception_info }}
+    {% endif -%}
     {%- if output.output | length < 10000 -%}
-    {
-      "returncode": {{ output.returncode }},
-      "output": {{ output.output | tojson }}
-      {%- if output.exception_info %}, "exception_info": {{ output.exception_info | tojson }}{% endif %}
-    }
+    {{ output.output }}
     {%- else -%}
-    {
-      "returncode": {{ output.returncode }},
-      "output_head": {{ output.output[:5000] | tojson }},
-      "output_tail": {{ output.output[-5000:] | tojson }},
-      "elided_chars": {{ output.output | length - 10000 }},
-      "warning": "Output too long."
-      {%- if output.exception_info %}, "exception_info": {{ output.exception_info | tojson }}{% endif %}
-    }
+    {{ output.output[:5000] }}
+    ... [{{ output.output | length - 10000 }} characters elided] ...
+    {{ output.output[-5000:] }}
     {%- endif -%}
+    [exit code {{ output.returncode }}]
   format_error_template: |
     Tool call error. Every response needs to use the 'bash' tool at least once to execute commands.
 
@@ -154,3 +148,4 @@ model:
   model_kwargs:
     drop_params: true
     temperature: 0.0
+    parallel_tool_calls: true

--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -52,7 +52,7 @@ agent:
     **CRITICAL REQUIREMENTS:**
 
     - Your response SHOULD include reasoning text explaining what you're doing
-    - Your response MUST include AT LEAST ONE bash tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase). This saves rounds and is strongly encouraged during exploration.
+    - Your response MUST include AT LEAST ONE bash tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase).
     - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
     - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
 
@@ -119,8 +119,8 @@ environment:
     PAGER: cat
     MANPAGER: cat
     LESS: -R
-    PIP_PROGRESS_BAR: 'off'
-    TQDM_DISABLE: '1'
+    PIP_PROGRESS_BAR: "off"
+    TQDM_DISABLE: "1"
   environment_class: docker
 
 model:

--- a/src/minisweagent/config/benchmarks/swebench.yaml
+++ b/src/minisweagent/config/benchmarks/swebench.yaml
@@ -125,16 +125,33 @@ environment:
 
 model:
   observation_template: |
-    {%- if output.exception_info %}Exception: {{ output.exception_info }}
+    {% if output.exception_info -%}
+    <exception>{{output.exception_info}}</exception>
     {% endif -%}
-    {%- if output.output | length < 10000 -%}
-    {{ output.output }}
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
     {%- else -%}
+    <warning>
+    The output of your last command was too long.
+    Please try a different command that produces less output.
+    If you're looking at a file you can try use head, tail or sed to view a smaller number of lines selectively.
+    If you're using grep or find and it produced too much output, you can use a more selective search pattern.
+    If you really need to see something from the full command's output, you can redirect output to a file and then search in that file.
+    </warning>
+    {%- set elided_chars = output.output | length - 10000 -%}
+    <output_head>
     {{ output.output[:5000] }}
-    ... [{{ output.output | length - 10000 }} characters elided] ...
+    </output_head>
+    <elided_chars>
+    {{ elided_chars }} characters elided
+    </elided_chars>
+    <output_tail>
     {{ output.output[-5000:] }}
+    </output_tail>
     {%- endif -%}
-    [exit code {{ output.returncode }}]
   format_error_template: |
     Tool call error. Every response needs to use the 'bash' tool at least once to execute commands.
 


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#722](https://github.com/SWE-agent/mini-swe-agent/pull/722)
> **Original author:** @aorwall
> **Originally opened:** 2026-02-02

---

- Allow multiple bash tool calls per response in the prompt
- Update example to show 3 concurrent tool calls
- Add parallel_tool_calls: true to model_kwargs
- Switch observation template from JSON (tojson) to plain text, reducing tool response size by ~32% per response

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
