### PR TITLE
Fix: Retry on transient API errors (500, etc.)

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -51,7 +51,6 @@ class LitellmModel:
         litellm.exceptions.NotFoundError,
         litellm.exceptions.PermissionDeniedError,
         litellm.exceptions.ContextWindowExceededError,
-        litellm.exceptions.APIError,
         litellm.exceptions.AuthenticationError,
         KeyboardInterrupt,
     ]


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#719](https://github.com/SWE-agent/mini-swe-agent/pull/719)
> **Original author:** @aorwall
> **Originally opened:** 2026-01-29

---

Remove APIError from abort_exceptions to enable retries on transient server errors like 500 Internal Server Error. Previously these errors would abort immediately instead of being retried with exponential backoff.
