### PR TITLE
chore: add git diff instructions to SWE-bench configs

### DIFF
--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -141,7 +141,7 @@ agent:
 
     Step 1: Create the patch file
     Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
-    Do NOT commit your changes. NEVER use `diff -u` or backup files.
+    Do NOT commit your changes.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.

--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -154,7 +154,6 @@ agent:
     </IMPORTANT>
 
     Step 2: Verify your patch
-    Run `git apply --check patch.txt` to ensure it's valid.
     Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
 
     Step 3: Submit (EXACT command required)

--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -140,7 +140,8 @@ agent:
     Follow these steps IN ORDER, with SEPARATE commands:
 
     Step 1: Create the patch file
-    Save a git diff of your changes to patch.txt.
+    Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
+    Do NOT commit your changes. NEVER use `diff -u` or backup files.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.
@@ -153,7 +154,8 @@ agent:
     </IMPORTANT>
 
     Step 2: Verify your patch
-    Inspect patch.txt to ensure it contains the correct changes.
+    Run `git apply --check patch.txt` to ensure it's valid.
+    Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
 
     Step 3: Submit (EXACT command required)
     You MUST use this EXACT command to submit:

--- a/src/minisweagent/config/extra/swebench_toolcall.yaml
+++ b/src/minisweagent/config/extra/swebench_toolcall.yaml
@@ -79,7 +79,7 @@ agent:
 
     Step 1: Create the patch file
     Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
-    Do NOT commit your changes. NEVER use `diff -u` or backup files.
+    Do NOT commit your changes.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.

--- a/src/minisweagent/config/extra/swebench_toolcall.yaml
+++ b/src/minisweagent/config/extra/swebench_toolcall.yaml
@@ -92,7 +92,6 @@ agent:
     </IMPORTANT>
 
     Step 2: Verify your patch
-    Run `git apply --check patch.txt` to ensure it's valid.
     Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
 
     Step 3: Submit (EXACT command required)

--- a/src/minisweagent/config/extra/swebench_toolcall.yaml
+++ b/src/minisweagent/config/extra/swebench_toolcall.yaml
@@ -78,7 +78,8 @@ agent:
     Follow these steps IN ORDER, with SEPARATE commands:
 
     Step 1: Create the patch file
-    Save a git diff of your changes to patch.txt.
+    Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
+    Do NOT commit your changes. NEVER use `diff -u` or backup files.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.
@@ -91,7 +92,8 @@ agent:
     </IMPORTANT>
 
     Step 2: Verify your patch
-    Inspect patch.txt to ensure it contains the correct changes.
+    Run `git apply --check patch.txt` to ensure it's valid.
+    Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
 
     Step 3: Submit (EXACT command required)
     You MUST use this EXACT command to submit:

--- a/src/minisweagent/config/extra/swebench_xml.yaml
+++ b/src/minisweagent/config/extra/swebench_xml.yaml
@@ -127,7 +127,7 @@ agent:
 
     Step 1: Create the patch file
     Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
-    Do NOT commit your changes. NEVER use `diff -u` or backup files.
+    Do NOT commit your changes.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.

--- a/src/minisweagent/config/extra/swebench_xml.yaml
+++ b/src/minisweagent/config/extra/swebench_xml.yaml
@@ -126,7 +126,8 @@ agent:
     Follow these steps IN ORDER, with SEPARATE commands:
 
     Step 1: Create the patch file
-    Save a git diff of your changes to patch.txt.
+    Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
+    Do NOT commit your changes. NEVER use `diff -u` or backup files.
 
     <IMPORTANT>
     The patch must only contain changes to the specific source files you modified to fix the issue.
@@ -139,7 +140,8 @@ agent:
     </IMPORTANT>
 
     Step 2: Verify your patch
-    Inspect patch.txt to ensure it contains the correct changes.
+    Run `git apply --check patch.txt` to ensure it's valid.
+    Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
 
     Step 3: Submit (EXACT command required)
     You MUST use this EXACT command to submit:

--- a/src/minisweagent/config/extra/swebench_xml.yaml
+++ b/src/minisweagent/config/extra/swebench_xml.yaml
@@ -140,7 +140,6 @@ agent:
     </IMPORTANT>
 
     Step 2: Verify your patch
-    Run `git apply --check patch.txt` to ensure it's valid.
     Inspect patch.txt to confirm it only contains your intended changes and headers show `--- a/` and `+++ b/` paths.
 
     Step 3: Submit (EXACT command required)


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#705](https://github.com/SWE-agent/mini-swe-agent/pull/705)
> **Original author:** @aorwall
> **Originally opened:** 2026-01-19

---

Add explicit git diff command format with file paths to patch creation instructions
