### PR TITLE
Fixes the unit test error: ModuleNotFoundError: No module named 'swerex'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "mkdocs-glightbox",
     "mkdocs-redirects",
     "portkey-ai",
+    "swe-rex",
 ]
 
 [project.urls]


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#693](https://github.com/SWE-agent/mini-swe-agent/pull/693)
> **Original author:** @frankdu
> **Originally opened:** 2026-01-07

---

The module swe-rex shall be added to the optional dev dependency list.

After the fix, the error is resolved. 

Before the fix, the repro steps:

$ uv sync
$ uv pip install -e ".[dev]"
$ pytest

==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/frank/Documents/work/experiments/mini-swe-agent-my
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 360 items / 1 error

=========================================================================================== ERRORS ===========================================================================================
______________________________________________________________ ERROR collecting tests/environments/extra/test_swerex_docker.py _______________________________________________________________
ImportError while importing test module '/Users/frank/Documents/work/experiments/mini-swe-agent-my/tests/environments/extra/test_swerex_docker.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/environments/extra/test_swerex_docker.py:3: in <module>
    from minisweagent.environments.extra.swerex_docker import SwerexDockerEnvironment
src/minisweagent/environments/extra/swerex_docker.py:5: in <module>
    from swerex.deployment.docker import DockerDeployment
E   ModuleNotFoundError: No module named 'swerex'
================================================================================== short test summary info ===================================================================================
ERROR tests/environments/extra/test_swerex_docker.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================================================================== 1 error in 16.13s ======================================================================================
