### PR TITLE
Avoid submitting on failed command output; return error to model

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -119,4 +119,6 @@ class DefaultAgent:
         """Raises Submitted exception with final output if the agent has finished its task."""
         lines = output.get("output", "").lstrip().splitlines(keepends=True)
         if lines and lines[0].strip() in ["MINI_SWE_AGENT_FINAL_OUTPUT", "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"]:
+            if output.get("returncode", 0) != 0:
+                return  # Command failed - let agent see error and retry
             raise Submitted("".join(lines[1:]))


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#691](https://github.com/SWE-agent/mini-swe-agent/pull/691)
> **Original author:** @aorwall
> **Originally opened:** 2026-01-07

---

Today, a failed git command can emit output that gets treated as the final submission, causing us to submit errors instead of patches.

This lets the model receive the error feedback and retry instead of submitting an error string in place of a patch.
