### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: typos-dict-v0.13.13
+    rev: v1
     hooks:
       - id: typos
         files: \.(py|md|rst|yaml|toml)


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#674](https://github.com/SWE-agent/mini-swe-agent/pull/674)
> **Original author:** @app/pre-commit-ci
> **Originally opened:** 2025-12-29

---

<!--pre-commit.ci start-->
updates:
- [github.com/crate-ci/typos: typos-dict-v0.13.13 → v1](https://github.com/crate-ci/typos/compare/typos-dict-v0.13.13...v1)
<!--pre-commit.ci end-->
