### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: typos-dict-v0.13.13
     hooks:
       - id: typos
         files: \.(py|md|rst|yaml|toml)
         exclude: pyproject.toml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.9
+    rev: v0.14.10
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#667](https://github.com/SWE-agent/mini-swe-agent/pull/667)
> **Original author:** @app/pre-commit-ci
> **Originally opened:** 2025-12-22

---

<!--pre-commit.ci start-->
updates:
- [github.com/crate-ci/typos: v1 → typos-dict-v0.13.13](https://github.com/crate-ci/typos/compare/v1...typos-dict-v0.13.13)
- [github.com/astral-sh/ruff-pre-commit: v0.14.9 → v0.14.10](https://github.com/astral-sh/ruff-pre-commit/compare/v0.14.9...v0.14.10)
<!--pre-commit.ci end-->
