### PR TITLE
fix: check exit code before accepting sentinel in has_finished()

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -117,6 +117,8 @@ class DefaultAgent:
 
     def has_finished(self, output: dict[str, str]):
         """Raises Submitted exception with final output if the agent has finished its task."""
+        if output.get("returncode", 0) != 0:
+            return
         lines = output.get("output", "").lstrip().splitlines(keepends=True)
         if lines and lines[0].strip() in ["MINI_SWE_AGENT_FINAL_OUTPUT", "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"]:
             raise Submitted("".join(lines[1:]))

--- a/tests/agents/test_default.py
+++ b/tests/agents/test_default.py
@@ -315,7 +315,7 @@ def test_step_output_includes_action(default_config):
     assert "output" in output
 
 
-def test_does_not_finish_on_failed_command():
+def test_does_not_finish_on_failed_command(default_config):
     """Test agent continues when command with sentinel fails (non-zero exit code)."""
     agent = DefaultAgent(
         model=DeterministicModel(
@@ -327,6 +327,7 @@ def test_does_not_finish_on_failed_command():
             ]
         ),
         env=LocalEnvironment(),
+        **default_config,
     )
 
     exit_status, result = agent.run("Test failed command with sentinel")


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#661](https://github.com/SWE-agent/mini-swe-agent/pull/661)
> **Original author:** @Chesars
> **Originally opened:** 2025-12-19

---

## Summary
- Check returncode before accepting the sentinel in `has_finished()`
- If the command fails (non-zero exit code), the agent continues instead of terminating, allowing it to see the error and retry

## Details
Currently, if a command like `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT && git add -A && git diff` fails after the echo, the agent still terminates because it already saw the sentinel. 

With this fix, we check the exit code first. If it's non-zero, we ignore the sentinel and let the agent continue, so it can see the error and attempt to recover.

This implements "Option 2" from #659 (explicitly check exit status).

## Note on breaking changes
Unlike Option 1 (changing command order), this approach is **not a breaking change** - existing prompts continue to work as before.

## Test plan
- [x] Added `test_does_not_finish_on_failed_command` test
- [x] All existing tests pass
