### PR TITLE
chore: exclude test files from Codecov coverage

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -14,3 +14,6 @@ github_checks:
   # Don't mark lines that aren't covered
   annotations: false
 
+ignore:
+  - "tests/**/*"
+


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#656](https://github.com/SWE-agent/mini-swe-agent/pull/656)
> **Original author:** @Chesars
> **Originally opened:** 2025-12-18

---

Exclude test files for cleaner coverage reports.

Closes #612
