### PR TITLE
Change: No default prompts in config

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -12,27 +12,12 @@ from minisweagent import Environment, Model
 
 @dataclass
 class AgentConfig:
-    # The default settings are the bare minimum to run the agent. Take a look at the config files for improved settings.
-    system_template: str = "You are a helpful assistant that can do anything."
-    instance_template: str = (
-        "Your task: {{task}}. Please reply with a single shell command in triple backticks. "
-        "To finish, the first line of the output of the shell command must be 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT'."
-    )
-    timeout_template: str = (
-        "The last command <command>{{action['action']}}</command> timed out and has been killed.\n"
-        "The output of the command was:\n"
-        "{% if output | length < 10000 -%}\n"
-        "<output>\n{{output}}\n</output>\n"
-        "{%- else -%}\n"
-        "<warning>Output was too long and has been truncated.</warning>\n"
-        "<output_head>\n{{ output[:5000] }}\n</output_head>\n"
-        "<elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>\n"
-        "<output_tail>\n{{ output[-5000:] }}\n</output_tail>\n"
-        "{%- endif %}\n"
-        "Please try another command and make sure to avoid those requiring interactive input."
-    )
-    format_error_template: str = "Please always provide EXACTLY ONE action in triple backticks."
-    action_observation_template: str = "Observation: {{output}}"
+    # Check the config files in minisweagent/config for example settings
+    system_template: str
+    instance_template: str
+    timeout_template: str
+    format_error_template: str
+    action_observation_template: str
     action_regex: str = r"```bash\s*\n(.*?)\n```"
     step_limit: int = 0
     cost_limit: float = 3.0

--- a/src/minisweagent/config/default.yaml
+++ b/src/minisweagent/config/default.yaml
@@ -142,6 +142,24 @@ agent:
 
     Note: In rare cases, if you need to reference a similar format in your command, you might have
     to proceed in two steps, first writing TRIPLEBACKTICKSBASH, then replacing them with ```bash.
+  timeout_template: |
+    The last command <command>{{action['action']}}</command> timed out and has been killed.
+    The output of the command was:
+    {% if output | length < 10000 -%}
+    <output>
+    {{output}}
+    </output>
+    {%- else -%}
+    <warning>Output was too long and has been truncated.</warning>
+    <output_head>
+    {{ output[:5000] }}
+    </output_head>
+    <elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>
+    <output_tail>
+    {{ output[-5000:] }}
+    </output_tail>
+    {%- endif %}
+    Please try another command and make sure to avoid those requiring interactive input.
   step_limit: 0.
   cost_limit: 0.
 environment:

--- a/src/minisweagent/config/extra/swebench.yaml
+++ b/src/minisweagent/config/extra/swebench.yaml
@@ -209,6 +209,24 @@ agent:
 
     If you have completed your assignment, please consult the first message about how to
     submit your solution (you will not be able to continue working on this task after that).
+  timeout_template: |
+    The last command <command>{{action['action']}}</command> timed out and has been killed.
+    The output of the command was:
+    {% if output | length < 10000 -%}
+    <output>
+    {{output}}
+    </output>
+    {%- else -%}
+    <warning>Output was too long and has been truncated.</warning>
+    <output_head>
+    {{ output[:5000] }}
+    </output_head>
+    <elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>
+    <output_tail>
+    {{ output[-5000:] }}
+    </output_tail>
+    {%- endif %}
+    Please try another command and make sure to avoid those requiring interactive input.
   step_limit: 250
   cost_limit: 3.
 

--- a/src/minisweagent/config/extra/swebench_roulette.yaml
+++ b/src/minisweagent/config/extra/swebench_roulette.yaml
@@ -209,6 +209,24 @@ agent:
 
     If you have completed your assignment, please consult the first message about how to
     submit your solution (you will not be able to continue working on this task after that).
+  timeout_template: |
+    The last command <command>{{action['action']}}</command> timed out and has been killed.
+    The output of the command was:
+    {% if output | length < 10000 -%}
+    <output>
+    {{output}}
+    </output>
+    {%- else -%}
+    <warning>Output was too long and has been truncated.</warning>
+    <output_head>
+    {{ output[:5000] }}
+    </output_head>
+    <elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>
+    <output_tail>
+    {{ output[-5000:] }}
+    </output_tail>
+    {%- endif %}
+    Please try another command and make sure to avoid those requiring interactive input.
   step_limit: 250
   cost_limit: 3.
 

--- a/src/minisweagent/config/extra/swebench_xml.yaml
+++ b/src/minisweagent/config/extra/swebench_xml.yaml
@@ -193,6 +193,24 @@ agent:
 
     If you have completed your assignment, please consult the first message about how to
     submit your solution (you will not be able to continue working on this task after that).
+  timeout_template: |
+    The last command <command>{{action['action']}}</command> timed out and has been killed.
+    The output of the command was:
+    {% if output | length < 10000 -%}
+    <output>
+    {{output}}
+    </output>
+    {%- else -%}
+    <warning>Output was too long and has been truncated.</warning>
+    <output_head>
+    {{ output[:5000] }}
+    </output_head>
+    <elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>
+    <output_tail>
+    {{ output[-5000:] }}
+    </output_tail>
+    {%- endif %}
+    Please try another command and make sure to avoid those requiring interactive input.
   step_limit: 250
   cost_limit: 3.
   action_regex: <bash_code>(.*?)</bash_code>

--- a/src/minisweagent/config/github_issue.yaml
+++ b/src/minisweagent/config/github_issue.yaml
@@ -128,6 +128,24 @@ agent:
     <action>
     ```
     </response_example>
+  timeout_template: |
+    The last command <command>{{action['action']}}</command> timed out and has been killed.
+    The output of the command was:
+    {% if output | length < 10000 -%}
+    <output>
+    {{output}}
+    </output>
+    {%- else -%}
+    <warning>Output was too long and has been truncated.</warning>
+    <output_head>
+    {{ output[:5000] }}
+    </output_head>
+    <elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>
+    <output_tail>
+    {{ output[-5000:] }}
+    </output_tail>
+    {%- endif %}
+    Please try another command and make sure to avoid those requiring interactive input.
   step_limit: 0.
   cost_limit: 0.
 

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -142,6 +142,24 @@ agent:
 
     Note: In rare cases, if you need to reference a similar format in your command, you might have
     to proceed in two steps, first writing TRIPLEBACKTICKSBASH, then replacing them with ```bash.
+  timeout_template: |
+    The last command <command>{{action['action']}}</command> timed out and has been killed.
+    The output of the command was:
+    {% if output | length < 10000 -%}
+    <output>
+    {{output}}
+    </output>
+    {%- else -%}
+    <warning>Output was too long and has been truncated.</warning>
+    <output_head>
+    {{ output[:5000] }}
+    </output_head>
+    <elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>
+    <output_tail>
+    {{ output[-5000:] }}
+    </output_tail>
+    {%- endif %}
+    Please try another command and make sure to avoid those requiring interactive input.
   step_limit: 0.
   cost_limit: 3.
   mode: confirm

--- a/tests/config/test_swebench_template.py
+++ b/tests/config/test_swebench_template.py
@@ -142,37 +142,63 @@ def test_action_observation_template_just_under_10000_chars():
     assert "Y" * 8000 in result
 
 
-def test_timeout_template_long_output():
-    """Test that long timeout output (> 10000 chars) is truncated with head/tail format"""
-    template_str = AgentConfig.timeout_template
-    template = Template(template_str, undefined=StrictUndefined)
+def test_agent_config_requires_templates():
+    """Test that AgentConfig now requires all template fields (no defaults in code)"""
+    import pytest
 
-    # Create mock action and long output (like recursive grep warnings)
-    action = {"action": "grep -R pattern ."}
-    long_output = "START_" + "A" * 8000 + "B" * 3000 + "_END"  # > 10000 characters
+    # AgentConfig should require all template fields now
+    with pytest.raises(TypeError, match="missing.*required positional arguments"):
+        AgentConfig()
 
-    # Render the template
-    result = template.render(action=action, output=long_output)
 
-    # Should contain truncation elements for long output
-    assert "<warning>" in result
-    assert "has been truncated" in result
-    assert "<output_head>" in result
-    assert "<elided_chars>" in result
-    assert "characters elided" in result
-    assert "<output_tail>" in result
+def test_timeout_template_config_with_truncation():
+    """Test that config files have timeout templates with truncation"""
+    from pathlib import Path
 
-    # Verify the head contains first part of output
-    assert "START_" in result
-    assert "AAAA" in result
+    import yaml
 
-    # Verify the tail contains last part of output
-    assert "_END" in result
-    assert "BBBB" in result
+    config_files = [
+        Path("src/minisweagent/config/default.yaml"),
+        Path("src/minisweagent/config/mini.yaml"),
+        Path("src/minisweagent/config/github_issue.yaml"),
+        Path("src/minisweagent/config/extra/swebench.yaml"),
+        Path("src/minisweagent/config/extra/swebench_xml.yaml"),
+        Path("src/minisweagent/config/extra/swebench_roulette.yaml"),
+    ]
 
-    # Should still contain basic timeout message
-    assert "<command>grep -R pattern .</command>" in result
-    assert "timed out" in result
+    for config_file in config_files:
+        with open(config_file) as f:
+            config = yaml.safe_load(f)
 
-    # Result should be bounded (not grow with input size)
-    assert len(result) < 15000
+        timeout_template = config.get("agent", {}).get("timeout_template")
+        assert timeout_template is not None, f"{config_file} missing timeout_template"
+
+        # Verify it has truncation logic
+        template = Template(timeout_template, undefined=StrictUndefined)
+        action = {"action": "grep -R pattern ."}
+        long_output = "START_" + "A" * 8000 + "B" * 3000 + "_END"
+
+        result = template.render(action=action, output=long_output)
+
+        # Should contain truncation elements for long output
+        assert "<warning>" in result, f"{config_file} missing truncation"
+        assert "has been truncated" in result
+        assert "<output_head>" in result
+        assert "<elided_chars>" in result
+        assert "characters elided" in result
+        assert "<output_tail>" in result
+
+        # Verify the head contains first part of output
+        assert "START_" in result
+        assert "AAAA" in result
+
+        # Verify the tail contains last part of output
+        assert "_END" in result
+        assert "BBBB" in result
+
+        # Should still contain basic timeout message
+        assert "<command>grep -R pattern .</command>" in result
+        assert "timed out" in result
+
+        # Result should be bounded (not grow with input size)
+        assert len(result) < 15000

--- a/tests/run/test_save.py
+++ b/tests/run/test_save.py
@@ -10,10 +10,17 @@ from minisweagent.run.utils.save import save_traj
 
 def test_save_traj_includes_class_names():
     """Test that save_traj includes the full class names with import paths."""
+    # Load default config
+    import yaml
+
+    config_path = Path("src/minisweagent/config/default.yaml")
+    with open(config_path) as f:
+        default_config = yaml.safe_load(f)["agent"]
+
     # Create a simple agent setup
     model = DeterministicModel(outputs=["echo 'test'"])
     env = LocalEnvironment()
-    agent = DefaultAgent(model, env)
+    agent = DefaultAgent(model, env, **default_config)
 
     # Run a minimal task to populate the agent
     agent.add_message("system", "test system message")


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#646](https://github.com/SWE-agent/mini-swe-agent/pull/646)
> **Original author:** @klieret
> **Originally opened:** 2025-12-16

---

Either we would end up putting very long config values into the
default.py file, or we end up with a trashy default config.
It's better to require to always sourcing a config.
