### PR TITLE
Ref: Switch to pydantic for internal representations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pyyaml",
     "requests",
     "jinja2",
+    "pydantic >= 2.0",  # v2 required for safe mutable default arguments
     "litellm >= 1.75.5",  # want to have gpt-5 support
     "tenacity",
     "rich",

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -3,15 +3,14 @@
 import re
 import subprocess
 import time
-from dataclasses import asdict, dataclass
 
 from jinja2 import StrictUndefined, Template
+from pydantic import BaseModel
 
 from minisweagent import Environment, Model
 
 
-@dataclass
-class AgentConfig:
+class AgentConfig(BaseModel):
     # The default settings are the bare minimum to run the agent. Take a look at the config files for improved settings.
     system_template: str = "You are a helpful assistant that can do anything."
     instance_template: str = (
@@ -71,7 +70,7 @@ class DefaultAgent:
         self.extra_template_vars = {}
 
     def render_template(self, template: str, **kwargs) -> str:
-        template_vars = asdict(self.config) | self.env.get_template_vars() | self.model.get_template_vars()
+        template_vars = self.config.model_dump() | self.env.get_template_vars() | self.model.get_template_vars()
         return Template(template, undefined=StrictUndefined).render(
             **kwargs, **template_vars, **self.extra_template_vars
         )

--- a/src/minisweagent/agents/interactive.py
+++ b/src/minisweagent/agents/interactive.py
@@ -7,7 +7,6 @@ There are three modes:
 """
 
 import re
-from dataclasses import dataclass, field
 from typing import Literal
 
 from prompt_toolkit.history import FileHistory
@@ -22,11 +21,10 @@ console = Console(highlight=False)
 prompt_session = PromptSession(history=FileHistory(global_config_dir / "interactive_history.txt"))
 
 
-@dataclass
 class InteractiveAgentConfig(AgentConfig):
     mode: Literal["human", "confirm", "yolo"] = "confirm"
     """Whether to confirm actions."""
-    whitelist_actions: list[str] = field(default_factory=list)
+    whitelist_actions: list[str] = []
     """Never confirm actions that match these regular expressions."""
     confirm_exit: bool = True
     """If the agent wants to finish, do we ask for confirmation from user?"""

--- a/src/minisweagent/agents/interactive_textual.py
+++ b/src/minisweagent/agents/interactive_textual.py
@@ -10,7 +10,6 @@ import threading
 import time
 import traceback
 from collections.abc import Iterable
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -27,11 +26,10 @@ from textual.widgets import Footer, Header, Input, Static, TextArea
 from minisweagent.agents.default import AgentConfig, DefaultAgent, NonTerminatingException, Submitted
 
 
-@dataclass
 class TextualAgentConfig(AgentConfig):
     mode: Literal["confirm", "yolo"] = "confirm"
     """Mode for action execution: 'confirm' requires user confirmation, 'yolo' executes immediately."""
-    whitelist_actions: list[str] = field(default_factory=list)
+    whitelist_actions: list[str] = []
     """Never confirm actions that match these regular expressions."""
     confirm_exit: bool = True
     """If the agent wants to finish, do we ask for confirmation from user?"""

--- a/src/minisweagent/environments/docker.py
+++ b/src/minisweagent/environments/docker.py
@@ -3,18 +3,18 @@ import os
 import shlex
 import subprocess
 import uuid
-from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from pydantic import BaseModel
 
-@dataclass
-class DockerEnvironmentConfig:
+
+class DockerEnvironmentConfig(BaseModel):
     image: str
     cwd: str = "/"
     """Working directory in which to execute commands."""
-    env: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = {}
     """Environment variables to set in the container."""
-    forward_env: list[str] = field(default_factory=list)
+    forward_env: list[str] = []
     """Environment variables to forward to the container.
     Variables are only forwarded if they are set in the host environment.
     In case of conflict with `env`, the `env` variables take precedence.
@@ -23,7 +23,7 @@ class DockerEnvironmentConfig:
     """Timeout for executing commands in the container."""
     executable: str = os.getenv("MSWEA_DOCKER_EXECUTABLE", "docker")
     """Path to the docker/container executable."""
-    run_args: list[str] = field(default_factory=lambda: ["--rm"])
+    run_args: list[str] = ["--rm"]
     """Additional arguments to pass to the docker/container executable.
     Default is ["--rm"], which removes the container after it exits.
     """
@@ -50,7 +50,7 @@ class DockerEnvironment:
         self._start_container()
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config)
+        return self.config.model_dump()
 
     def _start_container(self):
         """Start the Docker container and return the container ID."""

--- a/src/minisweagent/environments/extra/bubblewrap.py
+++ b/src/minisweagent/environments/extra/bubblewrap.py
@@ -17,51 +17,49 @@ import shutil
 import subprocess
 import tempfile
 import uuid
-from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel
 
-@dataclass
-class BubblewrapEnvironmentConfig:
+
+class BubblewrapEnvironmentConfig(BaseModel):
     cwd: str = ""
     """Working directory for the sandbox."""
-    env: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = {}
     """Dictionary of environment variables to set in the sandbox."""
     timeout: int = 30
     """Timeout for the command in seconds."""
     executable: str = os.getenv("MSWEA_BUBBLEWRAP_EXECUTABLE", "bwrap")
     """Path to the bubblewrap executable."""
-    wrapper_args: list[str] = field(
-        default_factory=lambda: [
-            "--unshare-user-try",
-            "--ro-bind",
-            "/usr",
-            "/usr",
-            "--ro-bind",
-            "/bin",
-            "/bin",
-            "--ro-bind",
-            "/lib",
-            "/lib",
-            "--ro-bind",
-            "/lib64",
-            "/lib64",
-            "--ro-bind",
-            "/etc",
-            "/etc",
-            "--tmpfs",
-            "/tmp",
-            "--proc",
-            "/proc",
-            "--dev",
-            "/dev",
-            "--new-session",
-            "--setenv",
-            "PATH",
-            "/usr/local/bin:/usr/sbin:/usr/bin:/bin",
-        ]
-    )
+    wrapper_args: list[str] = [
+        "--unshare-user-try",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--ro-bind",
+        "/bin",
+        "/bin",
+        "--ro-bind",
+        "/lib",
+        "/lib",
+        "--ro-bind",
+        "/lib64",
+        "/lib64",
+        "--ro-bind",
+        "/etc",
+        "/etc",
+        "--tmpfs",
+        "/tmp",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--new-session",
+        "--setenv",
+        "PATH",
+        "/usr/local/bin:/usr/sbin:/usr/bin:/bin",
+    ]
     """Arguments to pass to the bubblewrap executable."""
 
 
@@ -109,4 +107,4 @@ class BubblewrapEnvironment:
         self.cleanup()
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | platform.uname()._asdict()
+        return self.config.model_dump() | platform.uname()._asdict()

--- a/src/minisweagent/environments/extra/swerex_docker.py
+++ b/src/minisweagent/environments/extra/swerex_docker.py
@@ -1,19 +1,18 @@
 import asyncio
-from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from pydantic import BaseModel
 from swerex.deployment.docker import DockerDeployment
 from swerex.runtime.abstract import Command as RexCommand
 
 
-@dataclass
-class SwerexDockerEnvironmentConfig:
+class SwerexDockerEnvironmentConfig(BaseModel):
     image: str
     cwd: str = "/"
     """Working directory in which to execute commands."""
     timeout: int = 30
     """Timeout for executing commands in the container."""
-    deployment_extra_kwargs: dict[str, Any] = field(default_factory=dict)
+    deployment_extra_kwargs: dict[str, Any] = {}
     """Extra kwargs to pass to DockerDeployment."""
 
 
@@ -44,4 +43,4 @@ class SwerexDockerEnvironment:
         }
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config)
+        return self.config.model_dump()

--- a/src/minisweagent/environments/local.py
+++ b/src/minisweagent/environments/local.py
@@ -1,14 +1,14 @@
 import os
 import platform
 import subprocess
-from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from pydantic import BaseModel
 
-@dataclass
-class LocalEnvironmentConfig:
+
+class LocalEnvironmentConfig(BaseModel):
     cwd: str = ""
-    env: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = {}
     timeout: int = 30
 
 
@@ -35,4 +35,4 @@ class LocalEnvironment:
         return {"output": result.stdout, "returncode": result.returncode}
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | platform.uname()._asdict() | os.environ
+        return self.config.model_dump() | platform.uname()._asdict() | os.environ

--- a/src/minisweagent/environments/singularity.py
+++ b/src/minisweagent/environments/singularity.py
@@ -6,18 +6,18 @@ import shutil
 import subprocess
 import tempfile
 import uuid
-from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel
 
-@dataclass
-class SingularityEnvironmentConfig:
+
+class SingularityEnvironmentConfig(BaseModel):
     image: str
     cwd: str = "/"
-    env: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = {}
     """Environment variables to set in the container."""
-    forward_env: list[str] = field(default_factory=list)
+    forward_env: list[str] = []
     """Environment variables to forward to the container."""
     timeout: int = 30
     """Timeout for executing commands in the container."""
@@ -58,7 +58,7 @@ class SingularityEnvironment:
         return sandbox_dir
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config)
+        return self.config.model_dump()
 
     def execute(self, command: str, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         """Execute a command in a Singularity container and return the result as a dict."""

--- a/src/minisweagent/models/extra/roulette.py
+++ b/src/minisweagent/models/extra/roulette.py
@@ -1,12 +1,12 @@
 import random
-from dataclasses import asdict, dataclass
+
+from pydantic import BaseModel
 
 from minisweagent import Model
 from minisweagent.models import get_model
 
 
-@dataclass
-class RouletteModelConfig:
+class RouletteModelConfig(BaseModel):
     model_kwargs: list[dict]
     """The models to choose from"""
     model_name: str = "roulette"
@@ -27,7 +27,7 @@ class RouletteModel:
         return sum(model.n_calls for model in self.models)
 
     def get_template_vars(self) -> dict:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}
 
     def select_model(self) -> Model:
         return random.choice(self.models)
@@ -39,8 +39,7 @@ class RouletteModel:
         return response
 
 
-@dataclass
-class InterleavingModelConfig:
+class InterleavingModelConfig(BaseModel):
     model_kwargs: list[dict]
     sequence: list[int] | None = None
     """If set to 0, 0, 1, we will return the first model 2 times, then the second model 1 time,

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -2,11 +2,11 @@ import json
 import logging
 import os
 from collections.abc import Callable
-from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
 import litellm
+from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
@@ -21,10 +21,9 @@ from minisweagent.models.utils.cache_control import set_cache_control
 logger = logging.getLogger("litellm_model")
 
 
-@dataclass
-class LitellmModelConfig:
+class LitellmModelConfig(BaseModel):
     model_name: str
-    model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_kwargs: dict[str, Any] = {}
     litellm_model_registry: Path | str | None = os.getenv("LITELLM_MODEL_REGISTRY_PATH")
     set_cache_control: Literal["default_end"] | None = None
     """Set explicit cache control markers, for example for Anthropic models"""
@@ -98,4 +97,4 @@ class LitellmModel:
         }
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}

--- a/src/minisweagent/models/litellm_response_api_model.py
+++ b/src/minisweagent/models/litellm_response_api_model.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
 
 import litellm
 from tenacity import (
@@ -18,7 +17,6 @@ from minisweagent.models.utils.openai_utils import coerce_responses_text
 logger = logging.getLogger("litellm_response_api_model")
 
 
-@dataclass
 class LitellmResponseAPIModelConfig(LitellmModelConfig):
     pass
 

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import os
-from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
 import requests
+from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
@@ -19,10 +19,9 @@ from minisweagent.models.utils.cache_control import set_cache_control
 logger = logging.getLogger("openrouter_model")
 
 
-@dataclass
-class OpenRouterModelConfig:
+class OpenRouterModelConfig(BaseModel):
     model_name: str
-    model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_kwargs: dict[str, Any] = {}
     set_cache_control: Literal["default_end"] | None = None
     """Set explicit cache control markers, for example for Anthropic models"""
     cost_tracking: Literal["default", "ignore_errors"] = os.getenv("MSWEA_COST_TRACKING", "default")
@@ -123,4 +122,4 @@ class OpenRouterModel:
         }
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
-from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
 import litellm
+from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
@@ -27,10 +27,9 @@ except ImportError:
     )
 
 
-@dataclass
-class PortkeyModelConfig:
+class PortkeyModelConfig(BaseModel):
     model_name: str
-    model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_kwargs: dict[str, Any] = {}
     litellm_model_registry: Path | str | None = os.getenv("LITELLM_MODEL_REGISTRY_PATH")
     """We currently use litellm to calculate costs. Here you can register additional models to litellm's model registry.
     Note that this might change if we get better support for Portkey and change how we calculate costs.
@@ -105,7 +104,7 @@ class PortkeyModel:
         }
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}
 
     def _calculate_cost(self, response) -> float:
         response_for_cost_calc = response.model_copy()

--- a/src/minisweagent/models/portkey_response_api_model.py
+++ b/src/minisweagent/models/portkey_response_api_model.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from dataclasses import dataclass
 
 import litellm
 from tenacity import (
@@ -19,7 +18,6 @@ from minisweagent.models.utils.openai_utils import coerce_responses_text
 logger = logging.getLogger("portkey_response_api_model")
 
 
-@dataclass
 class PortkeyResponseAPIModelConfig(PortkeyModelConfig):
     pass
 

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import os
-from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import requests
+from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
@@ -18,10 +18,9 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 logger = logging.getLogger("requesty_model")
 
 
-@dataclass
-class RequestyModelConfig:
+class RequestyModelConfig(BaseModel):
     model_name: str
-    model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_kwargs: dict[str, Any] = {}
 
 
 class RequestyAPIError(Exception):
@@ -117,4 +116,4 @@ class RequestyModel:
         }
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}

--- a/src/minisweagent/models/test_models.py
+++ b/src/minisweagent/models/test_models.py
@@ -1,13 +1,13 @@
 import logging
 import time
-from dataclasses import asdict, dataclass
 from typing import Any
+
+from pydantic import BaseModel
 
 from minisweagent.models import GLOBAL_MODEL_STATS
 
 
-@dataclass
-class DeterministicModelConfig:
+class DeterministicModelConfig(BaseModel):
     outputs: list[str]
     model_name: str = "deterministic"
     cost_per_call: float = 1.0
@@ -39,4 +39,4 @@ class DeterministicModel:
         return {"content": output}
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}

--- a/src/minisweagent/run/utils/save.py
+++ b/src/minisweagent/run/utils/save.py
@@ -1,4 +1,3 @@
-import dataclasses
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -10,13 +9,6 @@ from minisweagent import Agent, __version__
 def _get_class_name_with_module(obj: Any) -> str:
     """Get the full class name with module path."""
     return f"{obj.__class__.__module__}.{obj.__class__.__name__}"
-
-
-def _asdict(obj: Any) -> dict:
-    """Convert config objects to dicts."""
-    if dataclasses.is_dataclass(obj):
-        return dataclasses.asdict(obj)  # type: ignore[arg-type]
-    return obj  # let's try our luck
 
 
 def save_traj(
@@ -62,9 +54,9 @@ def save_traj(
         data["info"]["model_stats"]["api_calls"] = agent.model.n_calls
         data["messages"] = agent.messages
         data["info"]["config"] = {
-            "agent": _asdict(agent.config),
-            "model": _asdict(agent.model.config),
-            "environment": _asdict(agent.env.config),
+            "agent": agent.config.model_dump(),
+            "model": agent.model.config.model_dump(),
+            "environment": agent.env.config.model_dump(),
             "agent_type": _get_class_name_with_module(agent),
             "model_type": _get_class_name_with_module(agent.model),
             "environment_type": _get_class_name_with_module(agent.env),

--- a/tests/config/test_swebench_template.py
+++ b/tests/config/test_swebench_template.py
@@ -144,7 +144,7 @@ def test_action_observation_template_just_under_10000_chars():
 
 def test_timeout_template_long_output():
     """Test that long timeout output (> 10000 chars) is truncated with head/tail format"""
-    template_str = AgentConfig.timeout_template
+    template_str = AgentConfig().timeout_template
     template = Template(template_str, undefined=StrictUndefined)
 
     # Create mock action and long output (like recursive grep warnings)

--- a/tests/models/test_portkey_response_api_model.py
+++ b/tests/models/test_portkey_response_api_model.py
@@ -244,10 +244,10 @@ def test_response_api_model_cache_control():
         messages_cached = [{"role": "user", "content": "test", "cache_control": {"type": "ephemeral"}}]
         mock_cache.return_value = messages_cached
 
-        model = PortkeyResponseAPIModel(model_name="gpt-5-mini", set_cache_control="last_message")
+        model = PortkeyResponseAPIModel(model_name="gpt-5-mini", set_cache_control="default_end")
         model.query(messages_original)
 
-        mock_cache.assert_called_once_with(messages_original, mode="last_message")
+        mock_cache.assert_called_once_with(messages_original, mode="default_end")
 
 
 def test_response_api_model_with_model_kwargs():

--- a/tests/run/test_swebench.py
+++ b/tests/run/test_swebench.py
@@ -1,9 +1,9 @@
 import json
-from dataclasses import asdict, dataclass
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 from minisweagent import package_dir
 from minisweagent.models.test_models import DeterministicModel
@@ -370,8 +370,7 @@ def test_redo_existing_true_overwrites_existing(github_test_data, tmp_path):
     assert result["swe-agent__test-repo-1"]["model_name_or_path"] == "deterministic"
 
 
-@dataclass
-class ExceptionModelConfig:
+class ExceptionModelConfig(BaseModel):
     model_name: str = "exception_model"
 
 
@@ -390,7 +389,7 @@ class ExceptionModel:
         raise self.exception_type(self.exception_message)
 
     def get_template_vars(self) -> dict[str, Any]:
-        return asdict(self.config) | {"n_model_calls": self.n_calls, "model_cost": self.cost}
+        return self.config.model_dump() | {"n_model_calls": self.n_calls, "model_cost": self.cost}
 
 
 @pytest.mark.slow


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#645](https://github.com/SWE-agent/mini-swe-agent/pull/645)
> **Original author:** @klieret
> **Originally opened:** 2025-12-16

---

Not only is this actually more elegant because of how pydantic handles mutable default arguments, but also it avoids some subtle bugs with serializing path objects etc. It also makes things more generalizable if we ever need to nest configs.

Closes #491
