### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         exclude: pyproject.toml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
+    rev: v0.14.9
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#641](https://github.com/SWE-agent/mini-swe-agent/pull/641)
> **Original author:** @app/pre-commit-ci
> **Originally opened:** 2025-12-15

---

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.14.8 → v0.14.9](https://github.com/astral-sh/ruff-pre-commit/compare/v0.14.8...v0.14.9)
<!--pre-commit.ci end-->
