### PR TITLE
fix: add truncation to timeout_template to prevent context overflow

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -20,7 +20,15 @@ class AgentConfig:
     )
     timeout_template: str = (
         "The last command <command>{{action['action']}}</command> timed out and has been killed.\n"
-        "The output of the command was:\n <output>\n{{output}}\n</output>\n"
+        "The output of the command was:\n"
+        "{% if output | length < 10000 -%}\n"
+        "<output>\n{{output}}\n</output>\n"
+        "{%- else -%}\n"
+        "<warning>Output was too long and has been truncated.</warning>\n"
+        "<output_head>\n{{ output[:5000] }}\n</output_head>\n"
+        "<elided_chars>{{ output | length - 10000 }} characters elided</elided_chars>\n"
+        "<output_tail>\n{{ output[-5000:] }}\n</output_tail>\n"
+        "{%- endif %}\n"
         "Please try another command and make sure to avoid those requiring interactive input."
     )
     format_error_template: str = "Please always provide EXACTLY ONE action in triple backticks."


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#639](https://github.com/SWE-agent/mini-swe-agent/pull/639)
> **Original author:** @aorwall
> **Originally opened:** 2025-12-14

---

The timeout_template was rendering command output without truncation, causing 41MB+ messages when commands like `grep -R` hit recursive symlinks and produced massive warning output before timing out.

This adds the same truncation logic used in action_observation_template:
- Output < 10000 chars: shown in full
- Output >= 10000 chars: first 5000 + last 5000 chars with warning
