### PR TITLE
Reraise original exception when retries are exhausted

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -41,6 +41,7 @@ class LitellmModel:
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
 
     @retry(
+        reraise=True,
         stop=stop_after_attempt(int(os.getenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "10"))),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/minisweagent/models/litellm_response_api_model.py
+++ b/src/minisweagent/models/litellm_response_api_model.py
@@ -28,6 +28,7 @@ class LitellmResponseAPIModel(LitellmModel):
         self._previous_response_id: str | None = None
 
     @retry(
+        reraise=True,
         stop=stop_after_attempt(10),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/minisweagent/models/openrouter_model.py
+++ b/src/minisweagent/models/openrouter_model.py
@@ -56,6 +56,7 @@ class OpenRouterModel:
         self._api_key = os.getenv("OPENROUTER_API_KEY", "")
 
     @retry(
+        reraise=True,
         stop=stop_after_attempt(int(os.getenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "10"))),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/minisweagent/models/portkey_model.py
+++ b/src/minisweagent/models/portkey_model.py
@@ -74,6 +74,7 @@ class PortkeyModel:
         self.client = Portkey(**client_kwargs)
 
     @retry(
+        reraise=True,
         stop=stop_after_attempt(int(os.getenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "10"))),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/minisweagent/models/portkey_response_api_model.py
+++ b/src/minisweagent/models/portkey_response_api_model.py
@@ -30,6 +30,7 @@ class PortkeyResponseAPIModel(PortkeyModel):
         self._previous_response_id: str | None = None
 
     @retry(
+        reraise=True,
         stop=stop_after_attempt(int(os.getenv("MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT", "10"))),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/minisweagent/models/requesty_model.py
+++ b/src/minisweagent/models/requesty_model.py
@@ -51,6 +51,7 @@ class RequestyModel:
         self._api_key = os.getenv("REQUESTY_API_KEY", "")
 
     @retry(
+        reraise=True,
         stop=stop_after_attempt(10),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         before_sleep=before_sleep_log(logger, logging.WARNING),


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#638](https://github.com/SWE-agent/mini-swe-agent/pull/638)
> **Original author:** @aorwall
> **Originally opened:** 2025-12-14

---

Add reraise=True to all @retry decorators so that when retries are exhausted, the original exception is re-raised instead of being wrapped in a RetryError. 

Fixes #635 
