### PR TITLE
Fix: Remove timestamp field from OpenAI Response API requests

### DIFF
--- a/src/minisweagent/models/litellm_response_api_model.py
+++ b/src/minisweagent/models/litellm_response_api_model.py
@@ -46,7 +46,7 @@ class LitellmResponseAPIModel(LitellmModel):
     def _query(self, messages: list[dict[str, str]], **kwargs):
         try:
             # Remove 'timestamp' field added by agent - not supported by OpenAI responses API
-            clean_messages = [{k: v for k, v in msg.items() if k != "timestamp"} for msg in messages]
+            clean_messages = [{"role": msg["role"], "content": msg["content"]} for msg in messages]
             resp = litellm.responses(
                 model=self.config.model_name,
                 input=clean_messages if self._previous_response_id is None else clean_messages[-1:],


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#637](https://github.com/SWE-agent/mini-swe-agent/pull/637)
> **Original author:** @aorwall
> **Originally opened:** 2025-12-13

---

## Summary
- The `timestamp` field added to messages by the agent is not supported by the OpenAI Response API, causing API errors
- Removed the `timestamp` field from messages before sending requests to the Response API
- Also cleaned up a debug `print()` statement
