### PR TITLE
Improve clarity of user prompts in the `micro` cli

### DIFF
--- a/src/microsweagent/agents/interactive.py
+++ b/src/microsweagent/agents/interactive.py
@@ -63,7 +63,7 @@ class InteractiveAgent(DefaultAgent):
             # We always add a message about the interrupt and then just proceed to the next step
             interruption_message = self._prompt_and_handle_special(
                 "\n\n[bold yellow]Interrupted.[/bold yellow] "
-                "[bold green]/h[/bold green] to show help, or [green]continue with comment/command[/green]"
+                "[green]type a comment/command[/green] (/h for available commands)"
                 "\n[bold yellow]>[/bold yellow] "
             ).strip()
             if not interruption_message or interruption_message in self._MODE_COMMANDS_MAPPING:
@@ -82,8 +82,7 @@ class InteractiveAgent(DefaultAgent):
     def ask_confirmation(self) -> None:
         prompt = (
             "[bold yellow]Execute?[/bold yellow] [green][bold]Enter[/bold] to confirm[/green], "
-            "[green bold]/h[/green bold] for help, "
-            "or [green]enter comment/command[/green]\n"
+            "or [green]type a comment/command[/green] (/h for available commands)\n"
             "[bold yellow]>[/bold yellow] "
         )
         match user_input := self._prompt_and_handle_special(prompt).strip():


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#170](https://github.com/SWE-agent/mini-swe-agent/pull/170)
> **Original author:** @carlosejimenez
> **Originally opened:** 2025-07-15

---

In the confirmation prompt, "enter comment/command" is slightly ambiguous. This PR proposes a reword to the interactive user prompts to make available commands clearer.

### Changes
- Updated confirmation prompt in `ask_confirmation()` method
- Updated interruption prompt in `step()` method's KeyboardInterrupt handler

### Before/After
**Before:**
```
Execute? Enter to confirm, /h for help, or enter comment/command
> 
```

**After:**
```
Execute? Enter to confirm, or type a comment/command (/h for available commands)
> 
```
