### PR TITLE
Update API key precedence and remove API key storing in global env

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,19 @@ MSWEA_LOCAL_CONFIG_PATH="/path/to/your/own/config"
 # Default model name
 # (default: not set)
 MSWEA_MODEL_NAME="claude-sonnet-4-20250514"
+
+# Default API key
+# (default: not set)
+MSWEA_MODEL_API_KEY="sk-..."
 ```
 
-In addition, if you are prompted for a model name & API key, it will be stored in the `.env` file
-as `API_KEY_<MODEL_NAME>`.
+### Special Case: Anthropic Models
+
+For Anthropic models, you can also use `ANTHROPIC_API_KEYS` for advanced parallel execution:
+
+```bash
+# Multiple Anthropic keys for parallel execution (separated by "::")
+ANTHROPIC_API_KEYS="key1::key2::key3"
+```
+
+This allows different threads to use different API keys to avoid prompt caching conflicts when running multiple agents in parallel.

--- a/src/microsweagent/models/__init__.py
+++ b/src/microsweagent/models/__init__.py
@@ -51,10 +51,12 @@ def get_model(input_model_name: str | None = None, config: dict | None = None) -
         config = {}
     config = copy.deepcopy(config)
     config["model_name"] = resolved_model_name
+
+    # API key resolution (from env -> config -> None)
     if "model_kwargs" not in config:
         config["model_kwargs"] = {}
-    if not config.get("model_kwargs", {}).get("api_key"):
-        config["model_kwargs"]["api_key"] = os.getenv(f"API_KEY_{resolved_model_name.upper().replace('-', '_')}") or ""
+    if from_env := os.getenv("MSWEA_MODEL_API_KEY"):
+        config["model_kwargs"]["api_key"] = from_env
     return get_model_class(resolved_model_name)(**config)
 
 
@@ -92,11 +94,4 @@ def prompt_for_model_name() -> str:
     )
     choice = console.input(msg)
     set_key(global_config_file, "MSWEA_MODEL_NAME", choice)
-    if api_key := console.input(
-        f"\n[bold yellow]Set your language model API key[/bold yellow]\n"
-        f"[dim]Ignore this, if you have already set the key as an environment variable.[/dim]\n"
-        f"[dim]The key will be stored in [green]'{global_config_file}'[/green][/dim]\n"
-        f"[bold yellow]Key (optional) > [/bold yellow]"
-    ):
-        set_key(global_config_file, f"API_KEY_{choice.upper().replace('-', '_')}", api_key)
     return choice

--- a/src/microsweagent/run/hello_world.py
+++ b/src/microsweagent/run/hello_world.py
@@ -20,7 +20,7 @@ def main(
         "-m",
         "--model",
         help="Model name (defaults to MSWEA_MODEL_NAME env var)",
-        prompt="What model do you want to use? (assuming that you've set the API key as the environment variable already)",
+        prompt="What model do you want to use?",
     ),
 ) -> DefaultAgent:
     agent = DefaultAgent(

--- a/tests/models/test_init.py
+++ b/tests/models/test_init.py
@@ -91,56 +91,82 @@ class TestGetModel:
     def test_env_var_overrides_config_api_key(self):
         """Test that MSWEA_MODEL_API_KEY overrides config api_key."""
         with patch.dict(os.environ, {"MSWEA_MODEL_API_KEY": "env-key"}):
-            with patch("microsweagent.models.get_model_class") as mock_get_class:
-                mock_get_class.return_value = lambda **kwargs: DeterministicModel(
+            # Capture the arguments passed to the model constructor
+            captured_kwargs = {}
+
+            def mock_model_constructor(**kwargs):
+                captured_kwargs.update(kwargs)
+                return DeterministicModel(
                     outputs=kwargs.get("outputs", ["test"]),
                     model_name=kwargs.get("model_name", "test"),
                 )
 
-                config = {"model_kwargs": {"api_key": "config-key"}, "outputs": ["test"]}
-                model = get_model("test-model", config)
+            with patch("microsweagent.models.get_model_class") as mock_get_class:
+                mock_get_class.return_value = mock_model_constructor
 
-                call_kwargs = mock_get_class.call_args[1]
-                assert call_kwargs["model_kwargs"]["api_key"] == "env-key"
+                config = {"model_kwargs": {"api_key": "config-key"}, "outputs": ["test"]}
+                get_model("test-model", config)
+
+                assert captured_kwargs["model_kwargs"]["api_key"] == "env-key"
 
     def test_config_api_key_used_when_no_env_var(self):
         """Test that config api_key is used when env var is not set."""
         with patch.dict(os.environ, {}, clear=True):
-            with patch("microsweagent.models.get_model_class") as mock_get_class:
-                mock_get_class.return_value = lambda **kwargs: DeterministicModel(
+            # Capture the arguments passed to the model constructor
+            captured_kwargs = {}
+
+            def mock_model_constructor(**kwargs):
+                captured_kwargs.update(kwargs)
+                return DeterministicModel(
                     outputs=kwargs.get("outputs", ["test"]),
                     model_name=kwargs.get("model_name", "test"),
                 )
 
+            with patch("microsweagent.models.get_model_class") as mock_get_class:
+                mock_get_class.return_value = mock_model_constructor
+
                 config = {"model_kwargs": {"api_key": "config-key"}, "outputs": ["test"]}
-                model = get_model("test-model", config)
-                
-                call_kwargs = mock_get_class.call_args[1]
-                assert call_kwargs["model_kwargs"]["api_key"] == "config-key"
+                get_model("test-model", config)
+
+                assert captured_kwargs["model_kwargs"]["api_key"] == "config-key"
 
     def test_env_var_sets_api_key_when_no_config_key(self):
         """Test that MSWEA_MODEL_API_KEY is used when config has no api_key."""
         with patch.dict(os.environ, {"MSWEA_MODEL_API_KEY": "env-key"}):
-            with patch("microsweagent.models.get_model_class") as mock_get_class:
-                mock_get_class.return_value = lambda **kwargs: DeterministicModel(
+            # Capture the arguments passed to the model constructor
+            captured_kwargs = {}
+
+            def mock_model_constructor(**kwargs):
+                captured_kwargs.update(kwargs)
+                return DeterministicModel(
                     outputs=kwargs.get("outputs", ["test"]),
                     model_name=kwargs.get("model_name", "test"),
                 )
+
+            with patch("microsweagent.models.get_model_class") as mock_get_class:
+                mock_get_class.return_value = mock_model_constructor
+
                 config = {"outputs": ["test"]}
-                model = get_model("test-model", config)
-                call_kwargs = mock_get_class.call_args[1]
-                assert call_kwargs["model_kwargs"]["api_key"] == "env-key"
+                get_model("test-model", config)
+                assert captured_kwargs["model_kwargs"]["api_key"] == "env-key"
 
     def test_no_api_key_when_none_provided(self):
         """Test that no api_key is set when neither env var nor config provide one."""
         with patch.dict(os.environ, {}, clear=True):
-            with patch("microsweagent.models.get_model_class") as mock_get_class:
-                mock_get_class.return_value = lambda **kwargs: DeterministicModel(
+            # Capture the arguments passed to the model constructor
+            captured_kwargs = {}
+
+            def mock_model_constructor(**kwargs):
+                captured_kwargs.update(kwargs)
+                return DeterministicModel(
                     outputs=kwargs.get("outputs", ["test"]),
                     model_name=kwargs.get("model_name", "test"),
                 )
+
+            with patch("microsweagent.models.get_model_class") as mock_get_class:
+                mock_get_class.return_value = mock_model_constructor
+
                 config = {"outputs": ["test"]}
-                model = get_model("test-model", config)
-                call_kwargs = mock_get_class.call_args[1]
-                model_kwargs = call_kwargs.get("model_kwargs", {})
+                get_model("test-model", config)
+                model_kwargs = captured_kwargs.get("model_kwargs", {})
                 assert "api_key" not in model_kwargs


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#137](https://github.com/SWE-agent/mini-swe-agent/pull/137)
> **Original author:** @carlosejimenez
> **Originally opened:** 2025-07-11

---

Note: Users should remove `api_key` keys from the global config to avoid confusion.
