### PR TITLE
avoid shutdown errors

### DIFF
--- a/src/microswea/agents/interactive_textual.py
+++ b/src/microswea/agents/interactive_textual.py
@@ -14,6 +14,7 @@ from rich.spinner import Spinner
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.events import Key
 from textual.widgets import Footer, Header, Static, TextArea
 
@@ -261,7 +262,10 @@ class AgentApp(App):
             spinner_frame = str(self._spinner.render(time.time())).strip()
             status_text = f"{self.agent_state} {spinner_frame}"
         self.title = f"Step {self.i_step + 1}/{self.n_steps} - {status_text} - Cost: ${self.agent.model.cost:.2f}"
-        self.query_one("Header").set_class(self.agent_state == "RUNNING", "running")
+        try:
+            self.query_one("Header").set_class(self.agent_state == "RUNNING", "running")
+        except NoMatches:  # might be called when shutting down
+            pass
 
     # --- Textual bindings ---
 

--- a/tests/agents/test_interactive_textual.py
+++ b/tests/agents/test_interactive_textual.py
@@ -166,9 +166,7 @@ async def test_log_message_filtering():
         model=DeterministicModel(
             outputs=[
                 "/warning Test warning message",
-                "/sleep 0.1",
                 "Normal response",
-                "/sleep 0.1",
                 "end: \n```\necho MICRO_SWE_AGENT_FINAL_OUTPUT\n```",
             ]
         ),
@@ -181,13 +179,7 @@ async def test_log_message_filtering():
     app.notify = Mock()
 
     async with app.run_test() as pilot:
-        # Wait for the agent to finish processing all messages
-        await pilot.pause(0.1)
-        while app.agent_state != "STOPPED":
-            await pilot.pause(0.1)
-
-        # Give a small buffer for any remaining async operations
-        await pilot.pause(0.1)
+        await pilot.pause(0.2)
 
         # Verify warning was emitted and handled (note the extra space in the actual format)
         app.notify.assert_called_with("[WARNING]  Test warning message", severity="warning")


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#59](https://github.com/SWE-agent/mini-swe-agent/pull/59)
> **Original author:** @klieret
> **Originally opened:** 2025-07-08

---

- **Fix: Avoid NoMatches errors when shutting down**
- **Revert "CI: Test fixing test_log_message_filtering (#57)"**
