### PR TITLE
Change: No need to return NO_OUTPUT when terminating emtpy

### DIFF
--- a/microswea/agents/default.py
+++ b/microswea/agents/default.py
@@ -106,4 +106,4 @@ class DefaultAgent:
     def has_finished(self, output: dict[str, str]):
         """Raises TerminatingException with final output if the agent has finished its task."""
         if output.get("stdout") and output["stdout"].splitlines()[0] == "MICRO_SWE_AGENT_FINAL_OUTPUT":
-            raise TerminatingException("\n".join(output["stdout"].splitlines()[1:]) or "EMPTY_OUTPUT")
+            raise TerminatingException("\n".join(output["stdout"].splitlines()[1:]))

--- a/tests/test_data/local.traj.json
+++ b/tests/test_data/local.traj.json
@@ -21,6 +21,6 @@
   },
   {
     "role": "user",
-    "content": "EMPTY_OUTPUT"
+    "content": ""
   }
 ]


### PR DESCRIPTION
> **Copied from upstream:** [SWE-agent/mini-swe-agent#48](https://github.com/SWE-agent/mini-swe-agent/pull/48)
> **Original author:** @klieret
> **Originally opened:** 2025-07-07

---

Closes #46
